### PR TITLE
Scale the width to maximum of 1 in area-adjusted plot

### DIFF
--- a/R/geom-lv.r
+++ b/R/geom-lv.r
@@ -169,7 +169,7 @@ GeomLv <- ggplot2::ggproto("GeomLv", ggplot2::Geom,
           uheight <- c(0, diff(data$upper))
           lwidth <- areas/lheight
           uwidth <- areas/uheight
-          maxwidth <- pmax(max(lwidth[is.finite(lwidth)]), max(uwidth[is.finite(uwidth)]))
+          maxwidth <- max(max(lwidth[is.finite(lwidth)]), max(uwidth[is.finite(uwidth)]))
 
           # offset <- (1- areas/lheight)*data$width/2
           offset <- (1-lwidth/maxwidth)*data$width/2

--- a/R/geom-lv.r
+++ b/R/geom-lv.r
@@ -169,7 +169,7 @@ GeomLv <- ggplot2::ggproto("GeomLv", ggplot2::Geom,
           uheight <- c(0, diff(data$upper))
           lwidth <- areas/lheight
           uwidth <- areas/uheight
-          maxwidth <- max(max(lwidth[is.finite(lwidth)]), max(uwidth[is.finite(uwidth)]))
+          maxwidth <- max(lwidth[is.finite(lwidth)], uwidth[is.finite(uwidth)])
 
           # offset <- (1- areas/lheight)*data$width/2
           offset <- (1-lwidth/maxwidth)*data$width/2

--- a/R/geom-lv.r
+++ b/R/geom-lv.r
@@ -167,8 +167,12 @@ GeomLv <- ggplot2::ggproto("GeomLv", ggplot2::Geom,
           areas <- 2^(-as.numeric(data$LV))
           lheight <- c(0, -diff(data$lower))
           uheight <- c(0, diff(data$upper))
+          lwidth <- areas/lheight
+          uwidth <- areas/uheight
+          maxwidth <- pmax(max(lwidth[is.finite(lwidth)]), max(uwidth[is.finite(uwidth)]))
 
-          offset <- (1- areas/lheight)*data$width/2
+          # offset <- (1- areas/lheight)*data$width/2
+          offset <- (1-lwidth/maxwidth)*data$width/2
           offset[is.infinite(offset)] <- data$width[1]/2
         }
       }
@@ -187,7 +191,8 @@ GeomLv <- ggplot2::ggproto("GeomLv", ggplot2::Geom,
     )
 
     if (width.method == "area") {
-      offset <- (1-areas/uheight)*data$width/2
+      # offset <- (1-areas/uheight)*data$width/2
+      offset <- (1-uwidth/maxwidth)*data$width/2
       offset[is.infinite(offset)] <- data$width[1]/2
     }
 


### PR DESCRIPTION
This PR is to scale the width of boxes in the area-adjusted plot. For example, 
```r
library(ggplot2)
library(lvplot)

ggplot(diamonds,aes(cut,price))+
  geom_lv(aes(fill=..LV..),width.method="area")
```
before:
![image](https://user-images.githubusercontent.com/7848019/34476483-891ffb08-efd4-11e7-8e89-2350910173a1.png)
after scaling:
![image](https://user-images.githubusercontent.com/7848019/34476507-abc80cea-efd4-11e7-8ba9-47a857b9b3af.png)

